### PR TITLE
Fix conversion lookup bug

### DIFF
--- a/src/Job Evaluation Tool.tsx
+++ b/src/Job Evaluation Tool.tsx
@@ -47,7 +47,7 @@ const JobEvaluationConversionTool = () => {
     let fromKey: ConversionDataKeys, toKey: ConversionDataKeys;
     switch (fromSystem) {
       case "Total Hay Job Size":
-        fromKey = value >= 1261 ? 'fromHay' : 'toHay';
+        fromKey = 'fromHay';
         break;
       case "Hay Level":
         fromKey = 'hayLevel';
@@ -87,7 +87,12 @@ const JobEvaluationConversionTool = () => {
         return;
     }
 
-    const matchingRow = conversionData.find(row => row[fromKey] <= value && value <= (fromKey === 'toHay' ? row.toHay : row[fromKey]));
+    let matchingRow;
+    if (fromSystem === "Total Hay Job Size") {
+      matchingRow = conversionData.find(row => row.fromHay <= value && value <= row.toHay);
+    } else {
+      matchingRow = conversionData.find(row => row[fromKey] === value);
+    }
     if (matchingRow) {
       setResult(`${toSystem}: ${matchingRow[toKey]}`);
     } else {


### PR DESCRIPTION
## Summary
- correct range matching logic in conversion tool

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6852946dcf40832cba50404a9112ee19